### PR TITLE
OPT: no need to insert an extra layer on `configure(**kwargs)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,8 @@ settings = Settings()
 settings.configure(hello='World', debug=False)
 ```
 
-By calling the configure you actually inject a `layer` of settings. When
-requesting a setting it will go through all layers until it finds the
-requested key.
-
 Now if someone starts using your package it can easily modify the active
-settings of your package by calling the configure again.
+settings of your package by calling the `configure()` again.
 
 ``` python
 from my_awesome_package.conf import settings
@@ -69,7 +65,7 @@ print(settings.debug) # This will print: True
 
 ## More advanced usage
 
-The settings object can also be used as context manager:
+The `settings` object can also be used as context manager:
 
 ``` python
 with settings(debug=True):
@@ -78,7 +74,7 @@ with settings(debug=True):
 print(settings.debug) # This will print: False
 ```
 
-Additionally you can also use this as a decorator:
+Additionally, you can also use this as a decorator:
 
 ``` python
 @settings(debug=True)

--- a/pkgsettings/pkgsettings.py
+++ b/pkgsettings/pkgsettings.py
@@ -69,16 +69,14 @@ class Settings(object):
             duration_field (string): Name of the field to store the duration value
         """
         if not obj:
-            obj = SimpleSettings()
+            top_layer = self._chain[0]
             for key, new_value in kwargs.items():
-                setattr(obj, key, new_value)
-
-        if obj is self:
+                setattr(top_layer, key, new_value)
+        elif obj is self:
             warnings.warn("Refusing to add ourselves to the chain", DuplicateConfigureWarning)
             return
-
-        self._chain.insert(0, obj)
-
+        else:
+            self._chain.insert(0, obj)
         if self._has_duplicates():
             warnings.warn("One setting was added multiple times, maybe a loop?", DuplicateConfigureWarning)
 


### PR DESCRIPTION
Reasoning:

- Adding another layer is functionally equivalent to modifying the top layer, unless there's a way to remove the top layer
- But the only way to remove the top layer is `__exit__()`, which implies an existence of an override layer created in `__enter__()`, which in turn is fine to overwrite