### PR TITLE
FIX: Strict typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: check-toml
+    - id: check-json
+- repo: https://github.com/psf/black
+  rev: 23.3.0
+  hooks:
+    - id: black
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.3.2
+  hooks:
+    - id: pyupgrade
+      args: ["--py37-plus"]
+- repo: https://github.com/pycqa/flake8
+  rev: '6.0.0'
+  hooks:
+    - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,11 @@ lint/isort: venv
 
 .PHONY: lint/mypy
 lint/mypy: venv
-	venv/bin/mypy $(SRC)
+	venv/bin/mypy --python-version 3.7 -p pkgsettings -p tests
+	venv/bin/mypy --python-version 3.8 -p pkgsettings -p tests
+	venv/bin/mypy --python-version 3.9 -p pkgsettings -p tests
+	venv/bin/mypy --python-version 3.10 -p pkgsettings -p tests
+	venv/bin/mypy --python-version 3.11 -p pkgsettings -p tests
 
 .PHONY: format
 format: format/isort format/black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,4 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
 [tool.mypy]
 check_untyped_defs = true
+strict = true

--- a/tests/test_pkgsettings.py
+++ b/tests/test_pkgsettings.py
@@ -1,3 +1,6 @@
+# mypy: allow-untyped-defs
+from dataclasses import dataclass
+
 from pytest import fail, raises, warns
 
 from pkgsettings import DuplicateConfigureWarning, PrefixedSettings, Settings
@@ -34,7 +37,7 @@ def test_decorator_in_class():
     settings = Settings()
     settings.configure(debug=False)
 
-    class Dummy(object):
+    class Dummy:
         @settings(debug=True)
         def go(self):
             assert settings.debug
@@ -54,9 +57,9 @@ def test_as_dict():
 
 
 def test_with_object():
+    @dataclass(frozen=True)
     class MySettings:
-        def __init__(self):
-            self.debug = False
+        debug: bool = False
 
     settings = Settings()
     settings.configure(MySettings())


### PR DESCRIPTION
Sets mypy to operate in strict mode by default. Additionally, change the signature of `__call__` to accomodate for a case where no parameters are provided (previously it would return `None`, which could potentially lead to complex error chain).